### PR TITLE
Automated Changelog Entry for 0.1.3 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.3
+
+([Full Changelog](https://github.com/davidbrochart/jupyter_ydoc/compare/v0.1.2...c68ebe54e500edde4eb34aa598dfb7bbb4d22b63))
+
+### Merged PRs
+
+- Add setuptools to install_requires [#7](https://github.com/davidbrochart/jupyter_ydoc/pull/7) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/davidbrochart/jupyter_ydoc/graphs/contributors?from=2022-05-05&to=2022-05-05&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Adavidbrochart%2Fjupyter_ydoc+involves%3Adavidbrochart+updated%3A2022-05-05..2022-05-05&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.2
 
 ([Full Changelog](https://github.com/davidbrochart/jupyter_ydoc/compare/v0.1.1...6a1fc44531344e1f930a7fd52b62cbd289873be0))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/davidbrochart/jupyter_ydoc/graphs/contributors?from=2022-05-04&to=2022-05-05&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Adavidbrochart%2Fjupyter_ydoc+involves%3Adavidbrochart+updated%3A2022-05-04..2022-05-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.3 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | davidbrochart/jupyter_ydoc  |
| Branch  | main  |
| Version Spec | 0.1.3 |
| Since | v0.1.2 |